### PR TITLE
fixes not-allowed hover for email during login/signup

### DIFF
--- a/frontend/src/components/authentication/Login.js
+++ b/frontend/src/components/authentication/Login.js
@@ -198,7 +198,7 @@ class Login extends Component {
                     </div>
                 </div>
                 <p className= "input-email">Email</p>
-                <input type="text" id="email" size="50" style={{width: '500px'}} onChange={this.handleChange}/>
+                <input type="text" id="login-email" size="50" style={{width: '500px'}} onChange={this.handleChange}/>
                 <br/>
                 <p className= "input-password">Password</p>
                 <div className = "link">

--- a/frontend/src/components/authentication/Signup.js
+++ b/frontend/src/components/authentication/Signup.js
@@ -234,7 +234,7 @@ class Signup extends Component {
                     <input type="text" id="lastName"  className="user-name" style={{width: '245px'}} onChange={this.handleChange} size="25" required/>
                 </div>
                 <p id = "input">Email</p>
-                <input type="email" className="account-info" id="email" size="50" style={{width: '500px'}} onChange={this.handleChange} required/>
+                <input type="email" className="account-info" id="signup-email" size="50" style={{width: '500px'}} onChange={this.handleChange} required/>
                 <p id = "input">Password</p>
                 <input type="password" className="account-info" id="password" style={{width: '500px'}} onChange={this.handleChange} 
                     pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{6,}" title="Must contain at least one number, one uppercase, and one lowercase letter, and at least 6 or more characters long"


### PR DESCRIPTION
Adding the profile page with the restricted ability to edit the email field accidentally caused the not-allowed symbol to show up over the email field when logging in or signing up.
To fix, I simply changed the IDs for the email field in the Login and Signup pages to be specific.
We don't currently use those IDs in any of the CSS, so no other modifications appeared to be necessary.